### PR TITLE
Correct the name of July from Cerweth to Cerveth

### DIFF
--- a/date-elv.elv
+++ b/date-elv.elv
@@ -32,7 +32,7 @@ fn date-elv {| option format |
 		  &April="Gwirith" 
 		  &May="Lothron" 
 		  &June="Nórui" 
-		  &July="Cerweth" 
+		  &July="Cerveth" 
 		  &August="Urui" 
 		  &September="Ivanneth" 
 		  &October="Narbeleth" 


### PR DESCRIPTION
"Cerveth" is well-sourced and generally accepted:

https://www.elfdict.com/w/cerveth

In contract, I've failed to find any sources for "Cerweth".