### PR TITLE
Correct the name of Saturday from Orgillion to Orgilion

### DIFF
--- a/date-elv.elv
+++ b/date-elv.elv
@@ -16,7 +16,7 @@ fn date-elv {| option format |
 
 	if (==s "-S" $option) {
 		set day-dict = [ 
-		  &Saturday="Orgillion" 
+		  &Saturday="Orgilion" 
 		  &Sunday="Oranor" 
 		  &Monday="Orithil" 
 		  &Tuesday="Orgaladh" 


### PR DESCRIPTION
Every source I know spells Orgilion with one L, not two.

https://www.elfdict.com/w/orgilion